### PR TITLE
Swapped discussion links for one of the original repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ redditClientId="your reddit client id"
 
 Feel free to post problems with the app as Github [Issues](https://github.com/1RandomDev/showly-oss/issues).
 
-Features ideas should be posted as new Github [Discussion](https://github.com/1RandomDev/showly-oss/discussions).
+Features ideas should be posted as new Github [Discussion](https://github.com/michaldrabik/showly-2.0/discussions).
 
 Pull requests are welcome. Remember about leaving a comment in the relevant issue if you are working on something.
 


### PR DESCRIPTION
Your repo doesn't have discussions enabled and returns a 404 error... I changed the discussion URL to at least go to the original repo